### PR TITLE
UnitTest：販売上限数が必ず1以上になるように修正。

### DIFF
--- a/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
+++ b/tests/Eccube/Tests/Web/Admin/Product/AbstractProductCommonTestCase.php
@@ -85,7 +85,7 @@ abstract class AbstractProductCommonTestCase extends AbstractAdminWebTestCase
             ->setCode('test code')
             ->setStock(100)
             ->setStockUnlimited(Constant::DISABLED)
-            ->setSaleLimit($this->faker->randomNumber(2))
+            ->setSaleLimit($this->faker->randomNumber(2) + 1)
             ->setPrice01($this->faker->randomNumber(4))
             ->setPrice02($this->faker->randomNumber(4))
             ->setDeliveryFee($this->faker->randomNumber(4))


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
UnitTest
販売制限数を乱数で生成しているのだが、
販売制限数が0になってテストNGになるのを修正。




