### PR TITLE
配送先作成時、商品種別の初期選択が逆順になっているのを修正。

### DIFF
--- a/src/Eccube/Repository/DeliveryRepository.php
+++ b/src/Eccube/Repository/DeliveryRepository.php
@@ -43,7 +43,7 @@ class DeliveryRepository extends EntityRepository
 
             $ProductType = $em
                 ->getRepository('\Eccube\Entity\Master\ProductType')
-                ->findOneBy(array(), array('rank' => 'DESC'));
+                ->findOneBy(array(), array('rank' => 'ASC'));
 
             $Delivery = $this->findOneBy(array(), array('rank' => 'DESC'));
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)

#2026 の変更の影響。
配送先作成時、商品種別の初期選択が逆順になっているのを修正しました。
期待値は「商品種別B」だが、「商品種別A」が初期値になっています。

## 実装に関する補足(Appendix)
mtb_product_typeのrank昇順に並べた先頭(=最もrankが小さい商品種別)が初期値になります。

## テスト（Test)
影響範囲は、配送先作成時の商品種別の初期選択のみです。
該当箇所をテストし、「商品種別A」が初期値になっていることを確認しました。

## 相談（Discussion）

3.0.14開発期間に入り込んだ不具合なので、3.0.14リリースまでに取り込みお願いします。



